### PR TITLE
Collapse consecutive assertThat statements using the same object

### DIFF
--- a/assertions-examples/src/test/java/org/assertj/examples/ArrayAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/ArrayAssertionsExamples.java
@@ -65,18 +65,21 @@ public class ArrayAssertionsExamples extends AbstractAssertionsExamples {
 
     Movie[] trilogy = array(theFellowshipOfTheRing, theTwoTowers, theReturnOfTheKing);
     assertThat(elvesRings).isNotEmpty().hasSize(3);
-    assertThat(elvesRings).hasSameSizeAs(trilogy);
-    assertThat(elvesRings).hasSameSizeAs(newArrayList(trilogy));
+    assertThat(elvesRings)
+            .hasSameSizeAs(trilogy)
+            .hasSameSizeAs(newArrayList(trilogy));
     assertThat(elvesRings).contains(nenya).doesNotContain(oneRing);
-    assertThat(elvesRings).containsExactly(vilya, nenya, narya);
-    assertThat(elvesRings).containsExactlyElementsOf(newArrayList(vilya, nenya, narya));
+    assertThat(elvesRings)
+            .containsExactly(vilya, nenya, narya)
+            .containsExactlyElementsOf(newArrayList(vilya, nenya, narya));
 
     // you can check element at a given index (we use Index.atIndex(int) synthetic sugar for better readability).
     assertThat(elvesRings).contains(vilya, atIndex(0)).contains(nenya, atIndex(1)).contains(narya, atIndex(2));
     // with containsOnly, all the elements must be present (but the order is not important)
-    assertThat(elvesRings).containsOnly(nenya, vilya, narya);
-    assertThat(elvesRings).containsOnlyElementsOf(newArrayList(nenya, vilya, narya));
-    assertThat(elvesRings).hasSameElementsAs(newArrayList(nenya, vilya, narya));
+    assertThat(elvesRings)
+            .containsOnly(nenya, vilya, narya)
+            .containsOnlyElementsOf(newArrayList(nenya, vilya, narya))
+            .hasSameElementsAs(newArrayList(nenya, vilya, narya));
     assertThat(elvesRings).doesNotContainNull().doesNotHaveDuplicates();
     assertThat(elvesRings).doesNotContainAnyElementsOf(newArrayList(oneRing, manRing, dwarfRing));
     // special check for null, empty collection or both
@@ -371,8 +374,9 @@ public class ArrayAssertionsExamples extends AbstractAssertionsExamples {
   @Test
   public void array_assertions_testing_elements_type() throws Exception {
     Number[] numbers = { 2, 6L, 8.0 };
-    assertThat(numbers).hasAtLeastOneElementOfType(Long.class);
-    assertThat(numbers).hasOnlyElementsOfType(Number.class);
+    assertThat(numbers)
+            .hasAtLeastOneElementOfType(Long.class)
+            .hasOnlyElementsOfType(Number.class);
   }
 
   @Test

--- a/assertions-examples/src/test/java/org/assertj/examples/BasicAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/BasicAssertionsExamples.java
@@ -213,9 +213,10 @@ public class BasicAssertionsExamples extends AbstractAssertionsExamples {
 
   @Test
   public void has_field_or_property_examples() {
+    assertThat(frodo).hasFieldOrProperty("age");
+    // private field is found unless Assertions.setAllowExtractingPrivateFields(false);
+    assertThat(frodo).hasFieldOrProperty("notAccessibleField");
     assertThat(frodo)
-            .hasFieldOrProperty("age")
-            .hasFieldOrProperty("notAccessibleField")
             .hasFieldOrPropertyWithValue("age", 33)
             .hasFieldOrProperty("race.name")
             .hasOnlyFields("age", "race", "name", "notAccessibleField")

--- a/assertions-examples/src/test/java/org/assertj/examples/BasicAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/BasicAssertionsExamples.java
@@ -116,8 +116,9 @@ public class BasicAssertionsExamples extends AbstractAssertionsExamples {
 
   @Test
   public void isIn_isNotIn_assertions_examples() {
-    assertThat(frodo).isIn(fellowshipOfTheRing);
-    assertThat(frodo).isIn(sam, frodo, pippin);
+    assertThat(frodo)
+            .isIn(fellowshipOfTheRing)
+            .isIn(sam, frodo, pippin);
     assertThat((TolkienCharacter) null).isIn(sam, frodo, pippin, null);
     assertThat(sauron).isNotIn(fellowshipOfTheRing);
     assertThat((TolkienCharacter) null).isNotIn(fellowshipOfTheRing);
@@ -212,13 +213,13 @@ public class BasicAssertionsExamples extends AbstractAssertionsExamples {
 
   @Test
   public void has_field_or_property_examples() {
-    assertThat(frodo).hasFieldOrProperty("age");
-    // private field are found unless Assertions.setAllowExtractingPrivateFields(false);
-    assertThat(frodo).hasFieldOrProperty("notAccessibleField");
-    assertThat(frodo).hasFieldOrPropertyWithValue("age", 33);
-    assertThat(frodo).hasFieldOrProperty("race.name");
-    assertThat(frodo).hasOnlyFields("age", "race", "name", "notAccessibleField");
-    assertThat(frodo).hasFieldOrPropertyWithValue("race.name", "Hobbit");
+    assertThat(frodo)
+            .hasFieldOrProperty("age")
+            .hasFieldOrProperty("notAccessibleField")
+            .hasFieldOrPropertyWithValue("age", 33)
+            .hasFieldOrProperty("race.name")
+            .hasOnlyFields("age", "race", "name", "notAccessibleField")
+            .hasFieldOrPropertyWithValue("race.name", "Hobbit");
   }
 
   @Test

--- a/assertions-examples/src/test/java/org/assertj/examples/IterableAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/IterableAssertionsExamples.java
@@ -104,8 +104,9 @@ public class IterableAssertionsExamples extends AbstractAssertionsExamples {
                           .isSubsetOf(duplicatedElvesRings);
 
     try {
-      assertThat(elvesRings).isSubsetOf(list(vilya, nenya, vilya, oneRing));
-      assertThat(elvesRings).containsOnly(nenya, vilya, oneRing);
+      assertThat(elvesRings)
+              .isSubsetOf(list(vilya, nenya, vilya, oneRing))
+              .containsOnly(nenya, vilya, oneRing);
     } catch (AssertionError e) {
       logAssertionErrorMessage("containsOnly", e);
     }
@@ -324,8 +325,9 @@ public class IterableAssertionsExamples extends AbstractAssertionsExamples {
   @Test
   public void iterable_is_subset_of_assertion_example() {
     Collection<Ring> elvesRings = list(vilya, nenya, narya);
-    assertThat(elvesRings).isSubsetOf(ringsOfPower);
-    assertThat(elvesRings).isSubsetOf(vilya, nenya, narya);
+    assertThat(elvesRings)
+            .isSubsetOf(ringsOfPower)
+            .isSubsetOf(vilya, nenya, narya);
     try {
       assertThat(elvesRings).isSubsetOf(list(nenya, narya));
     } catch (AssertionError e) {
@@ -442,17 +444,16 @@ public class IterableAssertionsExamples extends AbstractAssertionsExamples {
   @Test
   public void iterable_satisfy_assertion_example() {
     List<TolkienCharacter> hobbits = list(frodo, sam, pippin);
-    assertThat(hobbits).allSatisfy(character -> {
+    assertThat(hobbits)
+            .allSatisfy(character -> {
       assertThat(character.getRace()).isEqualTo(HOBBIT);
       assertThat(character.getName()).isNotEqualTo("Sauron");
-    });
-
-    assertThat(hobbits).anySatisfy(character -> {
+    })
+            .anySatisfy(character -> {
       assertThat(character.getRace()).isEqualTo(HOBBIT);
       assertThat(character.age).isLessThan(30);
-    });
-
-    assertThat(hobbits).noneSatisfy(character -> assertThat(character.getRace()).isEqualTo(ELF));
+    })
+            .noneSatisfy(character -> assertThat(character.getRace()).isEqualTo(ELF));
 
     // order is important, so frodo must satisfy the first lambda requirements, sam the second and pippin the last
     assertThat(hobbits).satisfiesExactly(character -> assertThat(character.getName()).isEqualTo("Frodo"),
@@ -599,12 +600,14 @@ public class IterableAssertionsExamples extends AbstractAssertionsExamples {
   public void iterable_assertions_testing_elements_type() throws Exception {
     List<Long> numbers = list(1L, 2L);
 
-    assertThat(numbers).hasOnlyElementsOfType(Number.class);
-    assertThat(numbers).hasOnlyElementsOfType(Long.class);
+    assertThat(numbers)
+            .hasOnlyElementsOfType(Number.class)
+            .hasOnlyElementsOfType(Long.class);
 
     List<? extends Object> mixed = list("string", 1L);
-    assertThat(mixed).hasAtLeastOneElementOfType(String.class);
-    assertThat(mixed).hasOnlyElementsOfTypes(Long.class, String.class);
+    assertThat(mixed)
+            .hasAtLeastOneElementOfType(String.class)
+            .hasOnlyElementsOfTypes(Long.class, String.class);
   }
 
   @Test
@@ -769,9 +772,10 @@ public class IterableAssertionsExamples extends AbstractAssertionsExamples {
   public void should_not_produce_warning_for_varargs_parameter() {
     List<Entry<String, String>> list = new ArrayList<>();
     list.add(Pair.of("A", "B"));
-    assertThat(list).containsAnyOf(Pair.of("A", "B"), Pair.of("C", "D"));
-    assertThat(list).containsExactly(Pair.of("A", "B"));
-    assertThat(list).contains(Pair.of("A", "B"));
+    assertThat(list)
+            .containsAnyOf(Pair.of("A", "B"), Pair.of("C", "D"))
+            .containsExactly(Pair.of("A", "B"))
+            .contains(Pair.of("A", "B"));
   }
 
   @Test

--- a/assertions-examples/src/test/java/org/assertj/examples/IterableAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/IterableAssertionsExamples.java
@@ -446,23 +446,26 @@ public class IterableAssertionsExamples extends AbstractAssertionsExamples {
     List<TolkienCharacter> hobbits = list(frodo, sam, pippin);
     assertThat(hobbits)
             .allSatisfy(character -> {
-      assertThat(character.getRace()).isEqualTo(HOBBIT);
-      assertThat(character.getName()).isNotEqualTo("Sauron");
-    })
+              assertThat(character.getRace()).isEqualTo(HOBBIT);
+              assertThat(character.getName()).isNotEqualTo("Sauron");
+            })
             .anySatisfy(character -> {
-      assertThat(character.getRace()).isEqualTo(HOBBIT);
-      assertThat(character.age).isLessThan(30);
-    })
+              assertThat(character.getRace()).isEqualTo(HOBBIT);
+              assertThat(character.age).isLessThan(30);
+            })
             .noneSatisfy(character -> assertThat(character.getRace()).isEqualTo(ELF));
 
     // order is important, so frodo must satisfy the first lambda requirements, sam the second and pippin the last
-    assertThat(hobbits).satisfiesExactly(character -> assertThat(character.getName()).isEqualTo("Frodo"),
-                                         character -> assertThat(character.getName()).isEqualTo("Sam"),
-                                         character -> assertThat(character.getName()).startsWith("Pip"))
-                       // order is not but all requirements must be met
-                       .satisfiesExactlyInAnyOrder(character -> assertThat(character.getName()).isEqualTo("Sam"),
-                                                   character -> assertThat(character.getName()).startsWith("Pip"),
-                                                   character -> assertThat(character.getName()).isEqualTo("Frodo"));
+    assertThat(hobbits)
+            .satisfiesExactly(
+                    character -> assertThat(character.getName()).isEqualTo("Frodo"),
+                    character -> assertThat(character.getName()).isEqualTo("Sam"),
+                    character -> assertThat(character.getName()).startsWith("Pip"))
+            // order is not but all requirements must be met
+            .satisfiesExactlyInAnyOrder(
+                    character -> assertThat(character.getName()).isEqualTo("Sam"),
+                    character -> assertThat(character.getName()).startsWith("Pip"),
+                    character -> assertThat(character.getName()).isEqualTo("Frodo"));
   }
 
   @Test

--- a/assertions-examples/src/test/java/org/assertj/examples/MapAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/MapAssertionsExamples.java
@@ -63,9 +63,10 @@ public class MapAssertionsExamples extends AbstractAssertionsExamples {
     assertThat(ringBearers).isNotEmpty().hasSize(4);
 
     // note the usage of Assertions.entry(key, value) synthetic sugar for better readability (similar to
-    // MapEntry.entry(key, value)).
     assertThat(ringBearers)
+            // MapEntry.entry(key, value)).
             .contains(entry(oneRing, frodo), entry(nenya, galadriel))
+            // using java util Map.Entry
             .contains(javaMapEntry(oneRing, frodo), javaMapEntry(nenya, galadriel));
     // same assertion but different way of expressing it : no entry call needed but no varargs support.
     assertThat(ringBearers).containsEntry(oneRing, frodo).containsEntry(nenya, galadriel);
@@ -79,8 +80,10 @@ public class MapAssertionsExamples extends AbstractAssertionsExamples {
     ringBearersInDifferentOrder.put(Ring.narya, gandalf);
     ringBearersInDifferentOrder.put(Ring.nenya, galadriel);
     ringBearersInDifferentOrder.put(Ring.vilya, elrond);
+    assertThat(ringBearers).containsExactlyInAnyOrderEntriesOf(ringBearersInDifferentOrder);
+
+    // Assertion on key
     assertThat(ringBearers)
-            .containsExactlyInAnyOrderEntriesOf(ringBearersInDifferentOrder)
             .containsKey(nenya)
             .containsKeys(nenya, narya)
             .containsValues(frodo, galadriel)

--- a/assertions-examples/src/test/java/org/assertj/examples/MapAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/MapAssertionsExamples.java
@@ -64,29 +64,29 @@ public class MapAssertionsExamples extends AbstractAssertionsExamples {
 
     // note the usage of Assertions.entry(key, value) synthetic sugar for better readability (similar to
     // MapEntry.entry(key, value)).
-    assertThat(ringBearers).contains(entry(oneRing, frodo), entry(nenya, galadriel));
-    // using java util Map.Entry
-    assertThat(ringBearers).contains(javaMapEntry(oneRing, frodo), javaMapEntry(nenya, galadriel));
+    assertThat(ringBearers)
+            .contains(entry(oneRing, frodo), entry(nenya, galadriel))
+            .contains(javaMapEntry(oneRing, frodo), javaMapEntry(nenya, galadriel));
     // same assertion but different way of expressing it : no entry call needed but no varargs support.
     assertThat(ringBearers).containsEntry(oneRing, frodo).containsEntry(nenya, galadriel);
     // opposite of contains/containsEntry
-    assertThat(ringBearers).doesNotContain(entry(oneRing, sauron), entry(nenya, aragorn));
-    assertThat(ringBearers).doesNotContainEntry(oneRing, aragorn);
+    assertThat(ringBearers)
+            .doesNotContain(entry(oneRing, sauron), entry(nenya, aragorn))
+            .doesNotContainEntry(oneRing, aragorn);
 
     Map<Ring, TolkienCharacter> ringBearersInDifferentOrder = new LinkedHashMap<>();
     ringBearersInDifferentOrder.put(Ring.oneRing, frodo);
     ringBearersInDifferentOrder.put(Ring.narya, gandalf);
     ringBearersInDifferentOrder.put(Ring.nenya, galadriel);
     ringBearersInDifferentOrder.put(Ring.vilya, elrond);
-    assertThat(ringBearers).containsExactlyInAnyOrderEntriesOf(ringBearersInDifferentOrder);
-
-    // Assertion on key
-    assertThat(ringBearers).containsKey(nenya);
-    assertThat(ringBearers).containsKeys(nenya, narya);
-    assertThat(ringBearers).containsValues(frodo, galadriel);
-    assertThat(ringBearers).containsOnlyKeys(nenya, narya, vilya, oneRing);
-    assertThat(ringBearers).doesNotContainKey(manRing);
-    assertThat(ringBearers).doesNotContainKeys(manRing, dwarfRing);
+    assertThat(ringBearers)
+            .containsExactlyInAnyOrderEntriesOf(ringBearersInDifferentOrder)
+            .containsKey(nenya)
+            .containsKeys(nenya, narya)
+            .containsValues(frodo, galadriel)
+            .containsOnlyKeys(nenya, narya, vilya, oneRing)
+            .doesNotContainKey(manRing)
+            .doesNotContainKeys(manRing, dwarfRing);
 
     try {
       assertThat(ringBearers).containsOnlyKeys(nenya, narya, dwarfRing);
@@ -95,13 +95,14 @@ public class MapAssertionsExamples extends AbstractAssertionsExamples {
     }
 
     // Assertion on value
-    assertThat(ringBearers).containsValue(frodo);
-    assertThat(ringBearers).doesNotContainValue(sam);
-
-    assertThat(ringBearers).hasSameSizeAs(ringBearers);
+    assertThat(ringBearers)
+            .containsValue(frodo)
+            .doesNotContainValue(sam)
+            .hasSameSizeAs(ringBearers);
     ringBearers.clear();
-    assertThat(ringBearers).contains();
-    assertThat(ringBearers).containsAllEntriesOf(ringBearers);
+    assertThat(ringBearers)
+            .contains()
+            .containsAllEntriesOf(ringBearers);
   }
 
   @Test
@@ -222,10 +223,11 @@ public class MapAssertionsExamples extends AbstractAssertionsExamples {
     ringBearers.put(frodo, oneRing);
     ringBearers.put(isildur, oneRing);
 
-    assertThat(ringBearers).hasEntrySatisfying(oneRingManBearer);
-    assertThat(ringBearers).hasEntrySatisfying(isMan, oneRingBearer);
-    assertThat(ringBearers).hasKeySatisfying(isMan);
-    assertThat(ringBearers).hasValueSatisfying(oneRingBearer);
+    assertThat(ringBearers)
+            .hasEntrySatisfying(oneRingManBearer)
+            .hasEntrySatisfying(isMan, oneRingBearer)
+            .hasKeySatisfying(isMan)
+            .hasValueSatisfying(oneRingBearer);
   }
 
   @Test


### PR DESCRIPTION
hi! Hope this is appreciated; was reading the examples and saw that these aren't using chained assertions as much as they could. Figured it'd be helpful to set the example that that is very much a thing you can do with AssertJ, to get away from repeated lines starting with the same `assertThat(actual)`.

If this is not appreciated also let me know; there's a few other improvements I'd held off on to make this easier to review.