### PR TITLE
Collapse consecutive assertions

### DIFF
--- a/assertions-examples/src/test/java/org/assertj/examples/ArrayAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/ArrayAssertionsExamples.java
@@ -249,11 +249,12 @@ public class ArrayAssertionsExamples extends AbstractAssertionsExamples {
 
   @Test
   public void containsOnlyOnce_for_primitive_types_assertion_examples() {
-    // int
-    assertThat(new int[] { 1, 2, 3 }).containsOnlyOnce(1);
-    assertThat(new int[] { 1, 2, 3 }).containsOnlyOnce(1, 2);
-    assertThat(new int[] { 1, 2, 3 }).containsOnlyOnce(1, 2, 3);
-    assertThat(new int[] { 1, 2, 3 }).containsOnlyOnce(3, 2, 3);
+    assertThat(new int[] { 1, 2, 3 })
+            // int
+            .containsOnlyOnce(1)
+            .containsOnlyOnce(1, 2)
+            .containsOnlyOnce(1, 2, 3)
+            .containsOnlyOnce(3, 2, 3);
     try {
       assertThat(new int[] { 1, 2, 1 }).containsOnlyOnce(1);
     } catch (AssertionError e) {
@@ -303,12 +304,13 @@ public class ArrayAssertionsExamples extends AbstractAssertionsExamples {
 
   @Test
   public void hasSameSizeAs_assertion_examples() {
-    // comparing primitive arrays with primitive arrays
-    assertThat(new byte[] { 1, 2 }).hasSameSizeAs(new byte[] { 2, 3 });
-    assertThat(new byte[] { 1, 2 }).hasSameSizeAs(new int[] { 2, 3 });
-    // comparing primitive arrays with Object array
-    assertThat(new byte[] { 1, 2 }).hasSameSizeAs(new Byte[] { 2, 3 });
-    assertThat(new byte[] { 1, 2 }).hasSameSizeAs(new String[] { "1", "2" });
+    assertThat(new byte[] { 1, 2 })
+            // comparing primitive arrays with primitive arrays
+            .hasSameSizeAs(new byte[] { 2, 3 })
+            .hasSameSizeAs(new int[] { 2, 3 })
+            // comparing primitive arrays with Object array
+            .hasSameSizeAs(new Byte[] { 2, 3 })
+            .hasSameSizeAs(new String[] { "1", "2" });
     // comparing primitive arrays with Iterable
     assertThat(new long[] { 1, 2, 3 }).hasSameSizeAs(newArrayList(vilya, nenya, narya));
 

--- a/assertions-examples/src/test/java/org/assertj/examples/BasicAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/BasicAssertionsExamples.java
@@ -213,9 +213,10 @@ public class BasicAssertionsExamples extends AbstractAssertionsExamples {
 
   @Test
   public void has_field_or_property_examples() {
-    assertThat(frodo).hasFieldOrProperty("age");
-    // private field is found unless Assertions.setAllowExtractingPrivateFields(false);
-    assertThat(frodo).hasFieldOrProperty("notAccessibleField");
+    assertThat(frodo)
+            .hasFieldOrProperty("age")
+            // private field is found unless Assertions.setAllowExtractingPrivateFields(false);
+            .hasFieldOrProperty("notAccessibleField");
     assertThat(frodo)
             .hasFieldOrPropertyWithValue("age", 33)
             .hasFieldOrProperty("race.name")

--- a/assertions-examples/src/test/java/org/assertj/examples/ComparableAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/ComparableAssertionsExamples.java
@@ -28,12 +28,15 @@ public class ComparableAssertionsExamples extends AbstractAssertionsExamples {
 
     Rating goodRating = new Rating(8);
     Rating badRating = new Rating(4);
-    assertThat(goodRating).isGreaterThan(badRating);
-    assertThat(goodRating).isGreaterThanOrEqualTo(badRating);
-    assertThat(badRating).isLessThan(goodRating);
-    assertThat(badRating).isLessThanOrEqualTo(goodRating);
-    assertThat(goodRating).isEqualByComparingTo(goodRating);
-    assertThat(goodRating).isNotEqualByComparingTo(badRating);
+    assertThat(goodRating)
+            .isGreaterThan(badRating)
+            .isGreaterThanOrEqualTo(badRating);
+    assertThat(badRating)
+            .isLessThan(goodRating)
+            .isLessThanOrEqualTo(goodRating);
+    assertThat(goodRating)
+            .isEqualByComparingTo(goodRating)
+            .isNotEqualByComparingTo(badRating);
     try {
       assertThat(badRating).isGreaterThan(goodRating);
     } catch (AssertionError e) {

--- a/assertions-examples/src/test/java/org/assertj/examples/DateAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/DateAssertionsExamples.java
@@ -103,14 +103,15 @@ public class DateAssertionsExamples extends AbstractAssertionsExamples {
     Date date4 = parseDatetimeWithMs("2003-01-01T01:55:55.555");
     Date date5 = parseDatetimeWithMs("2003-01-01T05:55:55.555");
 
-    assertThat(date1).isEqualToIgnoringMillis(date2);
-    assertThat(date1).isInSameSecondAs(date2);
-    assertThat(date1).isEqualToIgnoringSeconds(date3);
-    assertThat(date1).isInSameMinuteAs(date3);
-    assertThat(date1).isEqualToIgnoringMinutes(date4);
-    assertThat(date1).isInSameHourAs(date4);
-    assertThat(date1).isEqualToIgnoringHours(date5);
-    assertThat(date1).isInSameDayAs(date5);
+    assertThat(date1)
+            .isEqualToIgnoringMillis(date2)
+            .isInSameSecondAs(date2)
+            .isEqualToIgnoringSeconds(date3)
+            .isInSameMinuteAs(date3)
+            .isEqualToIgnoringMinutes(date4)
+            .isInSameHourAs(date4)
+            .isEqualToIgnoringHours(date5)
+            .isInSameDayAs(date5);
 
     try {
       assertThat(date1).isEqualToIgnoringMillis(date3);
@@ -143,9 +144,10 @@ public class DateAssertionsExamples extends AbstractAssertionsExamples {
       logAssertionErrorMessage("isInSameSecondAs date assertion", e);
     }
 
-    // succeeds because the time difference between dates < 1s
-    assertThat(date1).isInSameSecondWindowAs(date2);
-    assertThat(date1).isInSameSecondWindowAs(date3);
+    assertThat(date1)
+            // succeeds because the time difference between dates < 1s
+            .isInSameSecondWindowAs(date2)
+            .isInSameSecondWindowAs(date3);
     // fails because time difference between dates >= 1s
     try {
       assertThat(date1).isInSameSecondWindowAs(parseDatetimeWithMs("2003-01-01T12:00:02.000"));
@@ -171,9 +173,10 @@ public class DateAssertionsExamples extends AbstractAssertionsExamples {
       logAssertionErrorMessage("isInSameMinuteWindowAs date assertion", e);
     }
 
-    // succeeds because date time difference < 1 min
-    assertThat(date1).isInSameMinuteWindowAs(date2);
-    assertThat(date1).isInSameMinuteWindowAs(date3);
+    assertThat(date1)
+            // succeeds because date time difference < 1 min
+            .isInSameMinuteWindowAs(date2)
+            .isInSameMinuteWindowAs(date3);
     try {
       // fails because date time difference >= 1 min
       assertThat(date1).isInSameMinuteWindowAs(parseDatetime("2003-01-01T12:02:00"));
@@ -199,9 +202,10 @@ public class DateAssertionsExamples extends AbstractAssertionsExamples {
       logAssertionErrorMessage("isInSameHourAs date assertion", e);
     }
 
-    // succeeds because time difference < 1h
-    assertThat(date1).isInSameHourWindowAs(date2);
-    assertThat(date1).isInSameHourWindowAs(date3);
+    assertThat(date1)
+            // succeeds because time difference < 1h
+            .isInSameHourWindowAs(date2)
+            .isInSameHourWindowAs(date3);
     try {
       assertThat(date1).isInSameHourWindowAs(date4);
     } catch (AssertionError e) {
@@ -213,21 +217,23 @@ public class DateAssertionsExamples extends AbstractAssertionsExamples {
   public void is_in_the_same_day_or_month_or_year_assertions_examples() {
     Date date1 = parseDatetime("2003-04-26T23:17:00");
     Date date2 = parseDatetime("2003-04-26T12:30:00");
-    assertThat(date1).isInSameDayAs(date2);
-    assertThat(date1).isInSameMonthAs("2003-04-27");
-    assertThat(date1).isInSameYearAs("2003-05-13");
+    assertThat(date1)
+            .isInSameDayAs(date2)
+            .isInSameMonthAs("2003-04-27")
+            .isInSameYearAs("2003-05-13");
   }
 
   @Test
   public void has_field_date_assertions_examples() {
     Date date1 = parseDatetimeWithMs("2003-04-26T13:20:35.017");
-    assertThat(date1).hasMillisecond(17);
-    assertThat(date1).hasSecond(35);
-    assertThat(date1).hasMinute(20);
-    assertThat(date1).hasHourOfDay(13);
-    assertThat(date1).hasDayOfWeek(Calendar.SATURDAY);
-    assertThat(date1).hasMonth(4);
-    assertThat(date1).hasYear(2003);
+    assertThat(date1)
+            .hasMillisecond(17)
+            .hasSecond(35)
+            .hasMinute(20)
+            .hasHourOfDay(13)
+            .hasDayOfWeek(Calendar.SATURDAY)
+            .hasMonth(4)
+            .hasYear(2003);
   }
 
   @Test
@@ -304,12 +310,14 @@ public class DateAssertionsExamples extends AbstractAssertionsExamples {
 
     Assertions.setLenientDateParsing(true);
 
-    // assertions will pass
-    assertThat(date).isEqualTo("2001-01-34");
-    assertThat(date).isEqualTo("2001-02-02T24:00:00");
-    assertThat(date).isEqualTo("2001-02-04T-24:00:00.000");
-    assertThat(dateTime).isEqualTo("2001-02-03T04:05:05.1000");
-    assertThat(dateTime).isEqualTo("2001-02-03T04:04:66");
+    assertThat(date)
+            // assertions will pass
+            .isEqualTo("2001-01-34")
+            .isEqualTo("2001-02-02T24:00:00")
+            .isEqualTo("2001-02-04T-24:00:00.000");
+    assertThat(dateTime)
+            .isEqualTo("2001-02-03T04:05:05.1000")
+            .isEqualTo("2001-02-03T04:04:66");
     assertThat(dateTimeWithMs).isEqualTo("2001-02-03T04:05:07.-300");
 
     // assertions will fail

--- a/assertions-examples/src/test/java/org/assertj/examples/FileAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/FileAssertionsExamples.java
@@ -44,8 +44,9 @@ public class FileAssertionsExamples extends AbstractAssertionsExamples {
 
     // compare content with another file
     File xFileClone = writeFile("xFileClone", "The Truth Is Out There");
-    assertThat(xFile).hasSameTextualContentAs(xFileClone);
-    assertThat(xFile).hasSameBinaryContentAs(xFileClone);
+    assertThat(xFile)
+            .hasSameTextualContentAs(xFileClone)
+            .hasSameBinaryContentAs(xFileClone);
 
     // compare content with a string
     assertThat(xFile).isNotEmpty()

--- a/assertions-examples/src/test/java/org/assertj/examples/Java8DateTimeAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/Java8DateTimeAssertionsExamples.java
@@ -37,11 +37,12 @@ public class Java8DateTimeAssertionsExamples extends AbstractAssertionsExamples 
   public void zonedDateTime_assertions_examples() {
 
     ZonedDateTime firstOfJanuary2000InUTC = ZonedDateTime.parse("2000-01-01T00:00:00Z");
-    assertThat(firstOfJanuary2000InUTC).isEqualTo(ZonedDateTime.parse("2000-01-01T00:00:00Z"));
-    // same assertion but AssertJ takes care of expected String to ZonedDateTime conversion
-    assertThat(firstOfJanuary2000InUTC).isEqualTo("2000-01-01T00:00:00Z");
-    // example showing that ZonedDateTime are compared in actual's time zone
-    assertThat(firstOfJanuary2000InUTC).isEqualTo("2000-01-01T01:00:00+01:00");
+    assertThat(firstOfJanuary2000InUTC)
+            .isEqualTo(ZonedDateTime.parse("2000-01-01T00:00:00Z"))
+            // same assertion but AssertJ takes care of expected String to ZonedDateTime conversion
+            .isEqualTo("2000-01-01T00:00:00Z")
+            // example showing that ZonedDateTime are compared in actual's time zone
+            .isEqualTo("2000-01-01T01:00:00+01:00");
 
     try {
       // 2000-01-01T00:00+01:00 = 1999-12-31T23:00:00Z !
@@ -73,10 +74,11 @@ public class Java8DateTimeAssertionsExamples extends AbstractAssertionsExamples 
     ZonedDateTime zonedDateTime4 = ZonedDateTime.of(2000, 1, 1, 0, 0, 59, 999, ZoneOffset.UTC);
     ZonedDateTime zonedDateTime5 = ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 999, ZoneOffset.UTC);
 
-    assertThat(zonedDateTime1).isEqualToIgnoringHours(zonedDateTime2);
-    assertThat(zonedDateTime1).isEqualToIgnoringMinutes(zonedDateTime3);
-    assertThat(zonedDateTime1).isEqualToIgnoringSeconds(zonedDateTime4);
-    assertThat(zonedDateTime1).isEqualToIgnoringNanos(zonedDateTime5);
+    assertThat(zonedDateTime1)
+            .isEqualToIgnoringHours(zonedDateTime2)
+            .isEqualToIgnoringMinutes(zonedDateTime3)
+            .isEqualToIgnoringSeconds(zonedDateTime4)
+            .isEqualToIgnoringNanos(zonedDateTime5);
 
     // example showing that ZonedDateTime are compared in actual's time zone
     ZonedDateTime zonedDateTimeNotInUTC = ZonedDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC+1"));
@@ -233,8 +235,9 @@ public class Java8DateTimeAssertionsExamples extends AbstractAssertionsExamples 
     LocalTime _07_10 = LocalTime.of(7, 10);
     LocalTime _07_42 = LocalTime.of(7, 42);
 
-    assertThat(_07_10).isCloseTo(_07_42, within(32, ChronoUnit.MINUTES));
-    assertThat(_07_10).isCloseTo(_07_42, within(1, ChronoUnit.HOURS));
+    assertThat(_07_10)
+            .isCloseTo(_07_42, within(32, ChronoUnit.MINUTES))
+            .isCloseTo(_07_42, within(1, ChronoUnit.HOURS));
 
     LocalDate localDate = LocalDate.now();
     assertThat(localDate).isBetween(localDate.minusDays(1), localDate.plusDays(1))
@@ -308,9 +311,10 @@ public class Java8DateTimeAssertionsExamples extends AbstractAssertionsExamples 
   public void offsetDateTime_assertions_examples() {
 
     OffsetDateTime firstOfJanuary2000InUTC = OffsetDateTime.parse("2000-01-01T00:00:00Z");
-    assertThat(firstOfJanuary2000InUTC).isEqualTo(OffsetDateTime.parse("2000-01-01T00:00:00Z"));
-    // same assertion but AssertJ takes care of expected String to OffsetDateTime conversion
-    assertThat(firstOfJanuary2000InUTC).isEqualTo("2000-01-01T00:00:00Z");
+    assertThat(firstOfJanuary2000InUTC)
+            .isEqualTo(OffsetDateTime.parse("2000-01-01T00:00:00Z"))
+            // same assertion but AssertJ takes care of expected String to OffsetDateTime conversion
+            .isEqualTo("2000-01-01T00:00:00Z");
 
     try {
       // 2000-01-01T00:00+01:00 = 1999-12-31T23:00:00Z !
@@ -341,10 +345,11 @@ public class Java8DateTimeAssertionsExamples extends AbstractAssertionsExamples 
     OffsetDateTime offsetDateTime3 = OffsetDateTime.of(2000, 1, 1, 0, 59, 59, 999, ZoneOffset.UTC);
     OffsetDateTime offsetDateTime4 = OffsetDateTime.of(2000, 1, 1, 0, 0, 59, 999, ZoneOffset.UTC);
     OffsetDateTime offsetDateTime5 = OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 999, ZoneOffset.UTC);
-    assertThat(offsetDateTime1).isEqualToIgnoringHours(offsetDateTime2);
-    assertThat(offsetDateTime1).isEqualToIgnoringMinutes(offsetDateTime3);
-    assertThat(offsetDateTime1).isEqualToIgnoringSeconds(offsetDateTime4);
-    assertThat(offsetDateTime1).isEqualToIgnoringNanos(offsetDateTime5);
+    assertThat(offsetDateTime1)
+            .isEqualToIgnoringHours(offsetDateTime2)
+            .isEqualToIgnoringMinutes(offsetDateTime3)
+            .isEqualToIgnoringSeconds(offsetDateTime4)
+            .isEqualToIgnoringNanos(offsetDateTime5);
 
     // example showing that OffsetDateTime are compared in actual's time zone
     OffsetDateTime offsetDateTimeNotInUTC = OffsetDateTime.of(2000, 1, 1, 0, 0, 0, 0, ZoneOffset.MAX);

--- a/assertions-examples/src/test/java/org/assertj/examples/NumberAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/NumberAssertionsExamples.java
@@ -58,13 +58,15 @@ public class NumberAssertionsExamples extends AbstractAssertionsExamples {
     assertThat(frodo.age - sauron.age).isNegative();
     assertThat(gandalf.age - frodo.age).isPositive();
 
-    assertThat(frodo.age - frodo.age).isNotNegative();
-    assertThat(frodo.age - frodo.age).isNotPositive();
+    assertThat(frodo.age - frodo.age)
+            .isNotNegative()
+            .isNotPositive();
     assertThat(gandalf.age - frodo.age).isNotNegative();
     assertThat(frodo.age - sauron.age).isNotPositive();
 
-    assertThat(1.0f).isFinite();
-    assertThat(1.0).isFinite();
+    assertThat(1.0f)
+            .isFinite()
+            .isFinite();
   }
 
   @Test
@@ -137,11 +139,13 @@ public class NumberAssertionsExamples extends AbstractAssertionsExamples {
 
     // same stuff using within instead of offset
     assertThat(8.1).isCloseTo(8.0, within(0.1));
-    assertThat(0.2).isCloseTo(0.0, within(0.2));
-    assertThat(0.2).isCloseTo(0.0, byLessThan(0.20001));
-    assertThat(5.0).isCloseTo(6.0, withinPercentage(20.0));
-    assertThat(5.0).isCloseTo(6.0, withinPercentage(20));
-    assertThat(5).isCloseTo(6, withinPercentage(20));
+    assertThat(0.2)
+            .isCloseTo(0.0, within(0.2))
+            .isCloseTo(0.0, byLessThan(0.20001));
+    assertThat(5.0)
+            .isCloseTo(6.0, withinPercentage(20.0))
+            .isCloseTo(6.0, withinPercentage(20))
+            .isCloseTo(6, withinPercentage(20));
 
     assertThat(8.2f).isCloseTo(8.0f, within(0.2f));
     assertThat(new BigDecimal("8.1")).isCloseTo(new BigDecimal("8.0"), within(new BigDecimal("0.1")));
@@ -164,14 +168,14 @@ public class NumberAssertionsExamples extends AbstractAssertionsExamples {
     assertThat((short) 5).isCloseTo((short) 7, within((short) 3));
     assertThat((byte) 5).isCloseTo((byte) 7, within((byte) 3));
 
-    assertThat(8.1).isCloseTo(8.0, byLessThan(0.2));
-    // assertions succeed when the difference == offset value ...
-    assertThat(8.1).isCloseTo(8.0, within(0.1));
-
-    // ok as byLessThan is a strict offset
-    assertThat(8.1).isNotCloseTo(8.0, byLessThan(0.01));
-    assertThat(8.1).isNotCloseTo(8.0, within(0.01));
-    assertThat(8.1).isNotCloseTo(8.0, offset(0.01));
+    assertThat(8.1)
+            .isCloseTo(8.0, byLessThan(0.2))
+            // assertions succeed when the difference == offset value ...
+            .isCloseTo(8.0, within(0.1))
+            // ok as byLessThan is a strict offset
+            .isNotCloseTo(8.0, byLessThan(0.01))
+            .isNotCloseTo(8.0, within(0.01))
+            .isNotCloseTo(8.0, offset(0.01));
     // diff == offset but isNotCloseTo succeeds as we use byLessThan
     assertThat(0.1).isNotCloseTo(0.0, byLessThan(0.1));
     try {
@@ -180,83 +184,92 @@ public class NumberAssertionsExamples extends AbstractAssertionsExamples {
       logAssertionErrorMessage("int isNotCloseTo within ", e);
     }
 
-    assertThat(8.1f).isCloseTo(8.0f, within(0.2f));
-    assertThat(8.1f).isCloseTo(8.0f, offset(0.2f)); // alias of within
-    assertThat(8.1f).isCloseTo(8.0f, byLessThan(0.2f)); // strict
-
-    assertThat(8.1f).isNotCloseTo(8.0f, byLessThan(0.01f));
-    assertThat(8.1f).isNotCloseTo(8.0f, within(0.01f));
-    assertThat(8.1f).isNotCloseTo(8.0f, offset(0.01f));
+    assertThat(8.1f)
+            .isCloseTo(8.0f, within(0.2f))
+            .isCloseTo(8.0f, offset(0.2f))
+            // alias of within
+            .isCloseTo(8.0f, byLessThan(0.2f))
+            // strict
+            .isNotCloseTo(8.0f, byLessThan(0.01f))
+            .isNotCloseTo(8.0f, within(0.01f))
+            .isNotCloseTo(8.0f, offset(0.01f));
     // diff == offset but isNotCloseTo succeeds as we use byLessThan
     assertThat(0.1f).isNotCloseTo(0.0f, byLessThan(0.1f));
-    assertThat(8.1f).isEqualTo(8.0f, within(0.2f));
-    assertThat(8.1f).isEqualTo(8.0f, offset(0.2f)); // alias of within
-    assertThat(8.1f).isEqualTo(8.0f, byLessThan(0.2f)); // strict
+    assertThat(8.1f)
+            .isEqualTo(8.0f, within(0.2f))
+            .isEqualTo(8.0f, offset(0.2f))
+            // alias of within
+            .isEqualTo(8.0f, byLessThan(0.2f)); assertThat(0.1f)
+            // strict
+            // assertions succeed when the difference == offset value ...
+            .isCloseTo(0.0f, within(0.1f))
+            .isEqualTo(0.0f, within(0.1f));
 
-    // assertions succeed when the difference == offset value ...
-    assertThat(0.1f).isCloseTo(0.0f, within(0.1f));
-    assertThat(0.1f).isEqualTo(0.0f, within(0.1f));
-
-    assertThat(8.1f).isNotCloseTo(8.0f, byLessThan(0.01f));
-    assertThat(8.1f).isNotCloseTo(8.0f, within(0.01f));
-    assertThat(8.1f).isNotCloseTo(8.0f, offset(0.01f));
+    assertThat(8.1f)
+            .isNotCloseTo(8.0f, byLessThan(0.01f))
+            .isNotCloseTo(8.0f, within(0.01f))
+            .isNotCloseTo(8.0f, offset(0.01f));
     // diff == offset but isNotCloseTo succeeds as we use byLessThan
 
     assertThat(0.1f).isNotCloseTo(0.0f, byLessThan(0.1f));
-    assertThat(8.1f).isEqualTo(8.0f, within(0.2f));
-    assertThat(8.1f).isEqualTo(8.0f, offset(0.2f)); // alias of within
-    assertThat(8.1f).isEqualTo(8.0f, byLessThan(0.2f)); // strict
+    assertThat(8.1f)
+            .isEqualTo(8.0f, within(0.2f))
+            .isEqualTo(8.0f, offset(0.2f))
+            // alias of within
+            .isEqualTo(8.0f, byLessThan(0.2f)); assertThat(0.1f)
+            // strict
+            // assertions succeed when the difference == offset value ...
+            .isEqualTo(0.0f, within(0.1f))
+            .isEqualTo(0.0f, offset(0.1f));
+    assertThat(8.1f)
+            // ... except when using byLessThan which implies a strict comparison
+            // assertThat(0.1f).isEqualTo(0.0f, byLessThan(0.1f)); // strict => fail
+            .isEqualTo(8.0f, within(0.2f))
+            .isEqualTo(8.0f, offset(0.2f))
+            // alias of within
+            .isEqualTo(8.0f, byLessThan(0.2f)); assertThat(0.1f)
+            // strict
+            // assertions succeed when the difference == offset value ...
+            .isEqualTo(0.0f, within(0.1f))
+            .isEqualTo(0.0f, offset(0.1f));
 
-    // assertions succeed when the difference == offset value ...
-    assertThat(0.1f).isEqualTo(0.0f, within(0.1f));
-    assertThat(0.1f).isEqualTo(0.0f, offset(0.1f));
-    // ... except when using byLessThan which implies a strict comparison
-    // assertThat(0.1f).isEqualTo(0.0f, byLessThan(0.1f)); // strict => fail
-    assertThat(8.1f).isEqualTo(8.0f, within(0.2f));
-    assertThat(8.1f).isEqualTo(8.0f, offset(0.2f)); // alias of within
-    assertThat(8.1f).isEqualTo(8.0f, byLessThan(0.2f)); // strict
-
-    // assertions succeed when the difference == offset value ...
-    assertThat(0.1f).isEqualTo(0.0f, within(0.1f));
-    assertThat(0.1f).isEqualTo(0.0f, offset(0.1f));
-
-    assertThat(5).isCloseTo(7, within(3));
-    assertThat(5).isCloseTo(7, byLessThan(3));
-
-    // if difference is exactly equals to the offset, it's ok ...
-    assertThat(5).isNotCloseTo(7, byLessThan(1));
-    assertThat(5).isNotCloseTo(7, within(1));
-    // diff == offset but isNotCloseTo succeeds as we use byLessThan
-    assertThat(5).isNotCloseTo(7, byLessThan(2));
+    assertThat(5)
+            .isCloseTo(7, within(3))
+            .isCloseTo(7, byLessThan(3))
+            // if difference is exactly equals to the offset, it's ok ...
+            .isNotCloseTo(7, byLessThan(1))
+            .isNotCloseTo(7, within(1))
+            // diff == offset but isNotCloseTo succeeds as we use byLessThan
+            .isNotCloseTo(7, byLessThan(2));
 
     final BigDecimal eightDotOne = new BigDecimal("8.1");
     final BigDecimal eight = new BigDecimal("8.0");
 
-    // assertions succeed
-    assertThat(eightDotOne).isCloseTo(eight, within(new BigDecimal("0.2")));
-    assertThat(eightDotOne).isCloseTo(eight, Offset.offset(new BigDecimal("0.2"))); // alias of within
-    assertThat(eightDotOne).isCloseTo(eight, byLessThan(new BigDecimal("0.2"))); // strict
+    assertThat(eightDotOne)
+            // assertions succeed
+            .isCloseTo(eight, within(new BigDecimal("0.2")))
+            .isCloseTo(eight, Offset.offset(new BigDecimal("0.2")))
+            // alias of within
+            .isCloseTo(eight, byLessThan(new BigDecimal("0.2")))
+            // strict
+            .isCloseTo(eight, within(new BigDecimal("0.1")))
+            .isCloseTo(eight, Offset.offset(new BigDecimal("0.1")))
+            // assertions succeed
+            .isNotCloseTo(eight, byLessThan(new BigDecimal("0.01")))
+            .isNotCloseTo(eight, within(new BigDecimal("0.01")))
+            .isNotCloseTo(eight, Offset.offset(new BigDecimal("0.01")))
+            // diff == offset but isNotCloseTo succeeds as we use byLessThan
+            .isNotCloseTo(eight, byLessThan(new BigDecimal("0.1")));
 
-    assertThat(eightDotOne).isCloseTo(eight, within(new BigDecimal("0.1")));
-    assertThat(eightDotOne).isCloseTo(eight, Offset.offset(new BigDecimal("0.1")));
-
-    // assertions succeed
-    assertThat(eightDotOne).isNotCloseTo(eight, byLessThan(new BigDecimal("0.01")));
-    assertThat(eightDotOne).isNotCloseTo(eight, within(new BigDecimal("0.01")));
-    assertThat(eightDotOne).isNotCloseTo(eight, Offset.offset(new BigDecimal("0.01")));
-    // diff == offset but isNotCloseTo succeeds as we use byLessThan
-    assertThat(eightDotOne).isNotCloseTo(eight, byLessThan(new BigDecimal("0.1")));
-
-    assertThat(5l).isNotCloseTo(7l, byLessThan(1l));
-    assertThat(5l).isNotCloseTo(7l, within(1l));
-    // diff == offset but isNotCloseTo succeeds as we use byLessThan
-    assertThat(5l).isNotCloseTo(7l, byLessThan(2l));
-
-    assertThat(5L).isCloseTo(7L, within(3L));
-    assertThat(5L).isCloseTo(7L, byLessThan(3L));
-
-    // if difference is exactly equals to the offset, it's ok ...
-    assertThat(5L).isCloseTo(7L, within(2L));
+    assertThat(5l)
+            .isNotCloseTo(7l, byLessThan(1l))
+            .isNotCloseTo(7l, within(1l))
+            // diff == offset but isNotCloseTo succeeds as we use byLessThan
+            .isNotCloseTo(7l, byLessThan(2l))
+            .isCloseTo(7L, within(3L))
+            .isCloseTo(7L, byLessThan(3L))
+            // if difference is exactly equals to the offset, it's ok ...
+            .isCloseTo(7L, within(2L));
     // ... but not with byLessThan which implies a strict comparison
     assertThat((short) 10).isCloseTo((short) 11, byLessThan((short) 2));
 
@@ -275,12 +288,12 @@ public class NumberAssertionsExamples extends AbstractAssertionsExamples {
     final BigInteger eight = new BigInteger("8");
     final BigInteger ten = BigInteger.TEN;
 
-    // this assertion succeeds
-    assertThat(eight).isNotCloseTo(ten, byLessThan(BigInteger.ONE));
-    assertThat(eight).isNotCloseTo(ten, within(BigInteger.ONE));
-
-    // diff == offset but isNotCloseTo succeeds as we use byLessThan
-    assertThat(eight).isNotCloseTo(ten, byLessThan(new BigInteger("2")));
+    assertThat(eight)
+            // this assertion succeeds
+            .isNotCloseTo(ten, byLessThan(BigInteger.ONE))
+            .isNotCloseTo(ten, within(BigInteger.ONE))
+            // diff == offset but isNotCloseTo succeeds as we use byLessThan
+            .isNotCloseTo(ten, byLessThan(new BigInteger("2")));
   }
 
   @Test
@@ -369,8 +382,9 @@ public class NumberAssertionsExamples extends AbstractAssertionsExamples {
     assertThat(0.0).isEqualTo(-0.0);
     assertThat(-0.0).isEqualTo(0.0);
     assertThat(0.0).isNotEqualTo(Double.valueOf(-0.0));
-    assertThat(Double.NaN).isNotEqualTo(Double.NaN);
-    assertThat(Double.NaN).isEqualTo(Double.valueOf(Double.NaN));
+    assertThat(Double.NaN)
+            .isNotEqualTo(Double.NaN)
+            .isEqualTo(Double.valueOf(Double.NaN));
     assertThat(-0.0).isZero();
   }
 

--- a/assertions-examples/src/test/java/org/assertj/examples/OptionalAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/OptionalAssertionsExamples.java
@@ -50,9 +50,10 @@ public class OptionalAssertionsExamples extends AbstractAssertionsExamples {
     String someString = "something";
     assertThat(Optional.of(someString)).containsSame(someString);
     assertThat(Optional.of(someString)).hasValueSatisfying(s -> {
-      assertThat(s).isEqualTo("something");
-      assertThat(s).startsWith("some");
-      assertThat(s).endsWith("thing");
+      assertThat(s)
+              .isEqualTo("something")
+              .startsWith("some")
+              .endsWith("thing");
     });
 
     Condition<TolkienCharacter> isAnElf = new Condition<>(character -> character.getRace() == Race.ELF, "an elf");

--- a/assertions-examples/src/test/java/org/assertj/examples/PathAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/PathAssertionsExamples.java
@@ -87,8 +87,9 @@ public class PathAssertionsExamples extends AbstractAssertionsExamples {
     // compare paths content (uses the default charset)
 
     write(xFileClone, "The Truth Is Out There".getBytes());
-    assertThat(xFile).hasSameTextualContentAs(xFileClone);
-    assertThat(xFile).hasSameBinaryContentAs(xFileClone);
+    assertThat(xFile)
+            .hasSameTextualContentAs(xFileClone)
+            .hasSameBinaryContentAs(xFileClone);
 
     write(xFileFrench, "La Vérité Est Ailleurs".getBytes());
     try {
@@ -194,9 +195,9 @@ public class PathAssertionsExamples extends AbstractAssertionsExamples {
     assertThat(nonExistentPath).doesNotExist();
 
     assertThat(existingFile).isRegularFile();
-    assertThat(symlinkToExistingFile).isRegularFile();
-
-    assertThat(symlinkToExistingFile).isSymbolicLink();
+    assertThat(symlinkToExistingFile)
+            .isRegularFile()
+            .isSymbolicLink();
     assertThat(dirSymlink).isDirectory().isSymbolicLink();
     assertThat(symlinkToNonExistentPath).isSymbolicLink();
 

--- a/assertions-examples/src/test/java/org/assertj/examples/StringAssertionsExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/StringAssertionsExamples.java
@@ -181,8 +181,9 @@ public class StringAssertionsExamples extends AbstractAssertionsExamples {
                             "  </ring>\n" +
                             "</bearer>\n" +
                             "</rings>";
-    assertThat(xmlWithNewLine).isXmlEqualTo(expectedXml);
-    assertThat(xmlWithNewLine).isXmlEqualTo(oneLineXml);
+    assertThat(xmlWithNewLine)
+            .isXmlEqualTo(expectedXml)
+            .isXmlEqualTo(oneLineXml);
 
     // You can easily compare your XML String to the content of an XML file.
     assertThat(oneLineXml).isXmlEqualToContentOf(new File("src/test/resources/formatted.xml"));

--- a/assertions-examples/src/test/java/org/assertj/examples/condition/UsingConditionExamples.java
+++ b/assertions-examples/src/test/java/org/assertj/examples/condition/UsingConditionExamples.java
@@ -159,13 +159,15 @@ public class UsingConditionExamples extends AbstractAssertionsExamples {
 
   @Test
   public void combined_condition_example() {
-    assertThat("Yoda").has(jediPower);
-    assertThat("Yoda").has(allOf(jediPower, not(sithPower)));
-    assertThat("Solo").has(not(jediPower));
-    assertThat("Solo").doesNotHave(jediPower);
-    assertThat("Solo").is(allOf(not(JEDI), not(sith)));
-    assertThat("Solo").isNot(anyOf(JEDI, sith));
-    assertThat("Solo").doesNotHave(anyOf(jediPower, sithPower));
+    assertThat("Yoda")
+            .has(jediPower)
+            .has(allOf(jediPower, not(sithPower)));
+    assertThat("Solo")
+            .has(not(jediPower))
+            .doesNotHave(jediPower)
+            .is(allOf(not(JEDI), not(sith)))
+            .isNot(anyOf(JEDI, sith))
+            .doesNotHave(anyOf(jediPower, sithPower));
   }
 
   @Test


### PR DESCRIPTION
hi! I've recently expanded the recipe we have to collapse consecutive assertions into chained assertions:
- https://docs.openrewrite.org/recipes/java/testing/assertj/collapseconsecutiveassertthatstatements
- https://github.com/openrewrite/rewrite-testing-frameworks/pull/769
- https://github.com/openrewrite/rewrite-testing-frameworks/pull/775

This PR updates the examples to use that format where possible once more, as we did previously for simpler cases:
- https://github.com/assertj/assertj-examples/pull/65

My hope is tis helps folks once more to see what assertions can be chained, and the benefits of doing so.